### PR TITLE
Initialize TypeScript project scaffold with basic game loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>City Builder</title>
+  </head>
+  <body>
+    <canvas id="game" width="800" height="600"></canvas>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "city-builder",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests defined\""
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,0 +1,38 @@
+export class Game {
+  private lastTime = 0;
+  private accumulator = 0;
+  private readonly timestep = 1000 / 60; // 60 updates per second
+  private running = false;
+
+  constructor(private ctx: CanvasRenderingContext2D) {}
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    requestAnimationFrame(this.loop);
+  }
+
+  private loop = (time: number) => {
+    if (!this.running) return;
+    const delta = time - this.lastTime;
+    this.lastTime = time;
+    this.accumulator += delta;
+
+    while (this.accumulator >= this.timestep) {
+      this.update(this.timestep / 1000);
+      this.accumulator -= this.timestep;
+    }
+
+    this.render();
+    requestAnimationFrame(this.loop);
+  };
+
+  private update(dt: number) {
+    // Update game state here
+  }
+
+  private render() {
+    this.ctx.clearRect(0, 0, this.ctx.canvas.width, this.ctx.canvas.height);
+    // Render game objects here
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,10 @@
+import { Game } from './core/game';
+
+const canvas = document.getElementById('game') as HTMLCanvasElement;
+const ctx = canvas.getContext('2d');
+if (!ctx) {
+  throw new Error('Failed to get 2D context');
+}
+
+const game = new Game(ctx);
+game.start();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Scaffold TypeScript project with Vite scripts
- Add HTML canvas entry point and starter Game loop

## Testing
- `npm test`
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abf7eb75308332ad60cbff08cecc04