### PR TITLE
feat: add world rendering and camera controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_Store
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>City Builder</title>
+    <style>
+      html, body { margin: 0; height: 100%; overflow: hidden; }
+      canvas { display: block; }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "city-builder",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -1,0 +1,12 @@
+export class Camera {
+  x = 0;
+  y = 0;
+  scale = 1;
+
+  screenToWorld(x: number, y: number) {
+    return {
+      x: x / this.scale + this.x,
+      y: y / this.scale + this.y,
+    };
+  }
+}

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,0 +1,93 @@
+import { Camera } from './camera';
+import { World, TILE_SIZE, Tile } from '../world';
+
+export class Game {
+  private last = 0;
+  private readonly ctx: CanvasRenderingContext2D;
+  private readonly camera = new Camera();
+  private readonly world = new World(100, 100);
+
+  private isDragging = false;
+  private dragStart = { x: 0, y: 0 };
+  private dragMoved = false;
+  private cameraStart = { x: 0, y: 0 };
+
+  constructor(ctx: CanvasRenderingContext2D) {
+    this.ctx = ctx;
+    this.bindInput();
+    requestAnimationFrame(this.loop);
+  }
+
+  private bindInput() {
+    const canvas = this.ctx.canvas;
+
+    canvas.addEventListener('mousedown', (e) => {
+      this.isDragging = true;
+      this.dragMoved = false;
+      this.dragStart = { x: e.clientX, y: e.clientY };
+      this.cameraStart = { x: this.camera.x, y: this.camera.y };
+    });
+
+    canvas.addEventListener('mousemove', (e) => {
+      if (!this.isDragging) return;
+      const dx = (e.clientX - this.dragStart.x) / this.camera.scale;
+      const dy = (e.clientY - this.dragStart.y) / this.camera.scale;
+      if (dx !== 0 || dy !== 0) this.dragMoved = true;
+      this.camera.x = this.cameraStart.x - dx;
+      this.camera.y = this.cameraStart.y - dy;
+    });
+
+    const endDrag = (e: MouseEvent) => {
+      if (!this.isDragging) return;
+      this.isDragging = false;
+      if (!this.dragMoved) {
+        this.handleClick(e.offsetX, e.offsetY);
+      }
+    };
+
+    canvas.addEventListener('mouseup', endDrag);
+    canvas.addEventListener('mouseleave', endDrag);
+
+    canvas.addEventListener(
+      'wheel',
+      (e) => {
+        e.preventDefault();
+        const scaleFactor = e.deltaY > 0 ? 0.9 : 1.1;
+        const before = this.camera.screenToWorld(e.offsetX, e.offsetY);
+        this.camera.scale *= scaleFactor;
+        const after = this.camera.screenToWorld(e.offsetX, e.offsetY);
+        this.camera.x += before.x - after.x;
+        this.camera.y += before.y - after.y;
+      },
+      { passive: false }
+    );
+  }
+
+  private handleClick(x: number, y: number) {
+    const worldPos = this.camera.screenToWorld(x, y);
+    const tx = Math.floor(worldPos.x / TILE_SIZE);
+    const ty = Math.floor(worldPos.y / TILE_SIZE);
+    const current = this.world.get(tx, ty);
+    const next = current === Tile.Grass ? Tile.Water : Tile.Grass;
+    this.world.set(tx, ty, next);
+  }
+
+  private loop = (timestamp: number) => {
+    const delta = (timestamp - this.last) / 1000;
+    this.last = timestamp;
+
+    this.update(delta);
+    this.render();
+    requestAnimationFrame(this.loop);
+  };
+
+  private update(_dt: number) {
+    // Update game state if needed
+  }
+
+  private render() {
+    const { ctx } = this;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    this.world.render(ctx, this.camera);
+  }
+}

--- a/src/economy/index.ts
+++ b/src/economy/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for economy module
+export {};

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for entities module
+export {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,19 @@
+import { Game } from './core/game';
+
+function bootstrap() {
+  const canvas = document.createElement('canvas');
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context not supported');
+
+  new Game(ctx);
+
+  window.addEventListener('resize', () => {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  });
+}
+
+bootstrap();

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for ui module
+export {};

--- a/src/world/index.ts
+++ b/src/world/index.ts
@@ -1,0 +1,1 @@
+export { World, Tile, TILE_SIZE } from './world';

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -1,0 +1,47 @@
+export const TILE_SIZE = 32;
+
+export enum Tile {
+  Grass,
+  Water,
+}
+
+export class World {
+  private readonly tiles: Tile[];
+  constructor(public readonly width: number, public readonly height: number) {
+    this.tiles = new Array(width * height).fill(Tile.Grass);
+  }
+
+  get(x: number, y: number): Tile {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return Tile.Grass;
+    return this.tiles[y * this.width + x];
+  }
+
+  set(x: number, y: number, tile: Tile) {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
+    this.tiles[y * this.width + x] = tile;
+  }
+
+  render(ctx: CanvasRenderingContext2D, camera: { x: number; y: number; scale: number }) {
+    const { width, height } = ctx.canvas;
+    ctx.save();
+    ctx.scale(camera.scale, camera.scale);
+    ctx.translate(-camera.x, -camera.y);
+
+    const startX = Math.max(0, Math.floor(camera.x / TILE_SIZE));
+    const startY = Math.max(0, Math.floor(camera.y / TILE_SIZE));
+    const endX = Math.min(this.width, Math.ceil((camera.x + width / camera.scale) / TILE_SIZE));
+    const endY = Math.min(this.height, Math.ceil((camera.y + height / camera.scale) / TILE_SIZE));
+
+    for (let y = startY; y < endY; y++) {
+      for (let x = startX; x < endX; x++) {
+        const tile = this.get(x, y);
+        ctx.fillStyle = tile === Tile.Water ? '#6fa8dc' : '#93c47d';
+        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.strokeRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    ctx.restore();
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- render a tile-based world with basic camera
- support panning, zooming, and tile toggling on click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf7eb75308332ad60cbff08cecc04