### PR TITLE
feat: add tile-based world and camera controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_Store
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>City Builder</title>
+    <style>
+      html, body { margin: 0; padding: 0; overflow: hidden; }
+      canvas { display: block; }
+    </style>
+  </head>
+  <body>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "city-builder",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -1,0 +1,10 @@
+export class Camera {
+  x = 0;
+  y = 0;
+  zoom = 1;
+
+  move(dx: number, dy: number) {
+    this.x += dx;
+    this.y += dy;
+  }
+}

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,0 +1,108 @@
+import { Camera } from './camera';
+import { TileMap, tileColor } from '../world';
+
+const TILE_SIZE = 32;
+
+export class Game {
+  private last = 0;
+  private readonly ctx: CanvasRenderingContext2D;
+  private readonly world: TileMap;
+  private readonly camera = new Camera();
+  private dragging = false;
+  private lastPos = { x: 0, y: 0 };
+
+  constructor(ctx: CanvasRenderingContext2D) {
+    this.ctx = ctx;
+    this.world = new TileMap(100, 100);
+
+    const canvas = ctx.canvas;
+    canvas.addEventListener('pointerdown', this.onPointerDown);
+    canvas.addEventListener('pointermove', this.onPointerMove);
+    canvas.addEventListener('pointerup', this.onPointerUp);
+    canvas.addEventListener('pointerleave', this.onPointerUp);
+    canvas.addEventListener('wheel', this.onWheel, { passive: false });
+
+    requestAnimationFrame(this.loop);
+  }
+
+  private loop = (timestamp: number) => {
+    const delta = (timestamp - this.last) / 1000;
+    this.last = timestamp;
+
+    this.update(delta);
+    this.render();
+    requestAnimationFrame(this.loop);
+  };
+
+  private update(_dt: number) {
+    // For future simulation logic
+  }
+
+  private render() {
+    const { ctx, camera, world } = this;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+    ctx.save();
+    ctx.scale(camera.zoom, camera.zoom);
+    ctx.translate(-camera.x, -camera.y);
+
+    const startX = Math.floor(camera.x / TILE_SIZE);
+    const startY = Math.floor(camera.y / TILE_SIZE);
+    const endX = Math.ceil((camera.x + ctx.canvas.width / camera.zoom) / TILE_SIZE);
+    const endY = Math.ceil((camera.y + ctx.canvas.height / camera.zoom) / TILE_SIZE);
+
+    for (let y = startY; y < endY; y++) {
+      for (let x = startX; x < endX; x++) {
+        if (!world.inBounds(x, y)) continue;
+        ctx.fillStyle = tileColor(world.get(x, y));
+        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.strokeRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    ctx.restore();
+  }
+
+  private onPointerDown = (e: PointerEvent) => {
+    if (e.button === 0) {
+      const { x, y } = this.toWorld(e.clientX, e.clientY);
+      const tx = Math.floor(x / TILE_SIZE);
+      const ty = Math.floor(y / TILE_SIZE);
+      this.world.toggle(tx, ty);
+    } else {
+      this.dragging = true;
+      this.lastPos = { x: e.clientX, y: e.clientY };
+    }
+  };
+
+  private onPointerMove = (e: PointerEvent) => {
+    if (this.dragging) {
+      const dx = (e.clientX - this.lastPos.x) / this.camera.zoom;
+      const dy = (e.clientY - this.lastPos.y) / this.camera.zoom;
+      this.camera.move(-dx, -dy);
+      this.lastPos = { x: e.clientX, y: e.clientY };
+    }
+  };
+
+  private onPointerUp = (_e: PointerEvent) => {
+    this.dragging = false;
+  };
+
+  private onWheel = (e: WheelEvent) => {
+    e.preventDefault();
+    const worldPos = this.toWorld(e.clientX, e.clientY);
+    const scale = e.deltaY > 0 ? 0.9 : 1.1;
+    this.camera.zoom = Math.min(4, Math.max(0.5, this.camera.zoom * scale));
+    this.camera.x = worldPos.x - (e.clientX / this.camera.zoom);
+    this.camera.y = worldPos.y - (e.clientY / this.camera.zoom);
+  };
+
+  private toWorld(clientX: number, clientY: number) {
+    const rect = this.ctx.canvas.getBoundingClientRect();
+    return {
+      x: (clientX - rect.left) / this.camera.zoom + this.camera.x,
+      y: (clientY - rect.top) / this.camera.zoom + this.camera.y,
+    };
+  }
+}

--- a/src/economy/index.ts
+++ b/src/economy/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for economy module
+export {};

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for entities module
+export {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,18 @@
+import { Game } from './core/game';
+
+function bootstrap() {
+  const canvas = document.createElement('canvas');
+  const resize = () => {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  };
+  resize();
+  window.addEventListener('resize', resize);
+  document.body.appendChild(canvas);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context not supported');
+
+  new Game(ctx);
+}
+
+bootstrap();

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for ui module
+export {};

--- a/src/world/index.ts
+++ b/src/world/index.ts
@@ -1,0 +1,2 @@
+export * from './tile';
+export * from './tile-map';

--- a/src/world/tile-map.ts
+++ b/src/world/tile-map.ts
@@ -1,0 +1,36 @@
+import { Tile } from './tile';
+
+export class TileMap {
+  readonly width: number;
+  readonly height: number;
+  private readonly tiles: Tile[];
+
+  constructor(width: number, height: number) {
+    this.width = width;
+    this.height = height;
+    this.tiles = new Array(width * height).fill(Tile.Empty);
+  }
+
+  private index(x: number, y: number) {
+    return y * this.width + x;
+  }
+
+  inBounds(x: number, y: number) {
+    return x >= 0 && y >= 0 && x < this.width && y < this.height;
+  }
+
+  get(x: number, y: number): Tile {
+    return this.tiles[this.index(x, y)];
+  }
+
+  set(x: number, y: number, tile: Tile) {
+    if (this.inBounds(x, y)) {
+      this.tiles[this.index(x, y)] = tile;
+    }
+  }
+
+  toggle(x: number, y: number) {
+    const current = this.get(x, y);
+    this.set(x, y, current === Tile.Empty ? Tile.Building : Tile.Empty);
+  }
+}

--- a/src/world/tile.ts
+++ b/src/world/tile.ts
@@ -1,0 +1,14 @@
+export enum Tile {
+  Empty,
+  Building,
+}
+
+export function tileColor(tile: Tile): string {
+  switch (tile) {
+    case Tile.Building:
+      return '#777';
+    case Tile.Empty:
+    default:
+      return '#5caa4f';
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- render a tile-based world with a buildable grid
- add camera panning and zoom with tile placement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abf7eb75308332ad60cbff08cecc04