### PR TITLE
feat: integrate canvas bootstrap with HTML layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,19 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>City Builder</title>
+    <style>
+      html, body, #app {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        display: block;
+      }
+    </style>
   </head>
   <body>
+    <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,18 @@
 import { Game } from './core/game';
 
 function bootstrap() {
+  const root = document.getElementById('app') ?? document.body;
   const canvas = document.createElement('canvas');
-  canvas.width = window.innerWidth;
-  canvas.height = window.innerHeight;
-  document.body.appendChild(canvas);
+  root.appendChild(canvas);
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  window.addEventListener('resize', resize);
+  resize();
+
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas 2D context not supported');
 


### PR DESCRIPTION
## Summary
- restore HTML layout with meta tags and root container
- bootstrap canvas inside optional `#app` and handle resize to keep it fullscreen

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac03f29e488332a7f6d8e130a23baa