### PR TITLE
feat: add tile-based world rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.DS_Store
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>City Builder</title>
+    <style>
+      html, body, #app {
+        margin: 0;
+        width: 100%;
+        height: 100%;
+      }
+      canvas {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "city-builder",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.5",
+    "jest": "^29.7.0",
+    "jest-canvas-mock": "^2.5.1",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "jsdom",
+    "setupFiles": ["jest-canvas-mock"]
+  }
+}

--- a/src/core/camera.ts
+++ b/src/core/camera.ts
@@ -1,0 +1,17 @@
+export class Camera {
+  public x = 0;
+  public y = 0;
+  public scale = 1;
+
+  /**
+   * Convert screen coordinates to world coordinates based on the
+   * current camera translation and zoom level.
+   */
+  screenToWorld(screenX: number, screenY: number) {
+    return {
+      x: (screenX - this.x) / this.scale,
+      y: (screenY - this.y) / this.scale,
+    };
+  }
+}
+

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,0 +1,91 @@
+import { Camera } from './camera';
+import { World, TILE_SIZE, Tile } from '../world';
+
+/**
+ * Game loop and input handling for a simple tile-based world. Supports
+ * panning, zooming, and clicking tiles to toggle between grass and water.
+ */
+export class Game {
+  public readonly camera = new Camera();
+  public readonly world: World;
+
+  private last = 0;
+  private isPanning = false;
+  private lastPan = { x: 0, y: 0 };
+
+  constructor(private readonly ctx: CanvasRenderingContext2D, width = 100, height = 100) {
+    this.world = new World(width, height);
+    this.bindEvents();
+    requestAnimationFrame(this.loop);
+  }
+
+  private bindEvents() {
+    const canvas = this.ctx.canvas;
+    canvas.addEventListener('mousedown', (e) => this.handleMouseDown(e.clientX, e.clientY));
+    canvas.addEventListener('mousemove', (e) => this.handleMouseMove(e.clientX, e.clientY));
+    canvas.addEventListener('mouseup', () => this.handleMouseUp());
+    canvas.addEventListener('mouseleave', () => this.handleMouseUp());
+    canvas.addEventListener('click', (e) => this.handleClick(e.offsetX, e.offsetY));
+    canvas.addEventListener(
+      'wheel',
+      (e) => {
+        e.preventDefault();
+        this.handleWheel(e.deltaY, e.offsetX, e.offsetY);
+      },
+      { passive: false }
+    );
+  }
+
+  handleClick(screenX: number, screenY: number) {
+    const worldPos = this.camera.screenToWorld(screenX, screenY);
+    const tx = Math.floor(worldPos.x / TILE_SIZE);
+    const ty = Math.floor(worldPos.y / TILE_SIZE);
+    const current = this.world.get(tx, ty);
+    const next = current === Tile.Grass ? Tile.Water : Tile.Grass;
+    this.world.set(tx, ty, next);
+  }
+
+  handleMouseDown(x: number, y: number) {
+    this.isPanning = true;
+    this.lastPan = { x, y };
+  }
+
+  handleMouseMove(x: number, y: number) {
+    if (!this.isPanning) return;
+    this.camera.x += x - this.lastPan.x;
+    this.camera.y += y - this.lastPan.y;
+    this.lastPan = { x, y };
+  }
+
+  handleMouseUp() {
+    this.isPanning = false;
+  }
+
+  handleWheel(deltaY: number, x = 0, y = 0) {
+    const zoomFactor = deltaY > 0 ? 0.9 : 1.1;
+    const before = this.camera.screenToWorld(x, y);
+    this.camera.scale *= zoomFactor;
+    this.camera.x = x - before.x * this.camera.scale;
+    this.camera.y = y - before.y * this.camera.scale;
+  }
+
+  private loop = (timestamp: number) => {
+    const dt = (timestamp - this.last) / 1000;
+    this.last = timestamp;
+
+    this.update(dt);
+    this.render();
+    requestAnimationFrame(this.loop);
+  };
+
+  private update(_dt: number) {
+    // Future game state updates
+  }
+
+  private render() {
+    const { ctx } = this;
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    this.world.render(ctx, this.camera);
+  }
+}
+

--- a/src/economy/index.ts
+++ b/src/economy/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for economy module
+export {};

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for entities module
+export {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,22 @@
+import { Game } from './core/game';
+
+function bootstrap() {
+  const root = document.getElementById('app') ?? document.body;
+  const canvas = document.createElement('canvas');
+  root.appendChild(canvas);
+
+  function resize() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  window.addEventListener('resize', resize);
+  resize();
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context not supported');
+
+  new Game(ctx);
+}
+
+bootstrap();

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,2 @@
+// Placeholder for ui module
+export {};

--- a/src/world/index.ts
+++ b/src/world/index.ts
@@ -1,0 +1,1 @@
+export { World, Tile, TILE_SIZE } from './world';

--- a/src/world/world.ts
+++ b/src/world/world.ts
@@ -1,0 +1,59 @@
+export const TILE_SIZE = 32;
+
+export enum Tile {
+  Grass,
+  Water,
+}
+
+export class World {
+  private readonly tiles: Tile[];
+
+  constructor(public readonly width: number, public readonly height: number) {
+    this.tiles = new Array(width * height).fill(Tile.Grass);
+  }
+
+  get(x: number, y: number): Tile {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return Tile.Grass;
+    return this.tiles[y * this.width + x];
+  }
+
+  set(x: number, y: number, tile: Tile) {
+    if (x < 0 || y < 0 || x >= this.width || y >= this.height) return;
+    this.tiles[y * this.width + x] = tile;
+  }
+
+  render(
+    ctx: CanvasRenderingContext2D,
+    camera: { x: number; y: number; scale: number }
+  ) {
+    const { width: canvasWidth, height: canvasHeight } = ctx.canvas;
+    const scale = camera.scale;
+
+    const startX = Math.max(0, Math.floor((-camera.x) / (scale * TILE_SIZE)));
+    const startY = Math.max(0, Math.floor((-camera.y) / (scale * TILE_SIZE)));
+    const endX = Math.min(
+      this.width,
+      Math.ceil((canvasWidth - camera.x) / (scale * TILE_SIZE))
+    );
+    const endY = Math.min(
+      this.height,
+      Math.ceil((canvasHeight - camera.y) / (scale * TILE_SIZE))
+    );
+
+    ctx.save();
+    ctx.setTransform(scale, 0, 0, scale, camera.x, camera.y);
+
+    for (let y = startY; y < endY; y++) {
+      for (let x = startX; x < endX; x++) {
+        const tile = this.get(x, y);
+        ctx.fillStyle = tile === Tile.Water ? '#6fa8dc' : '#93c47d';
+        ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+        ctx.strokeStyle = 'rgba(0,0,0,0.1)';
+        ctx.strokeRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    ctx.restore();
+  }
+}
+

--- a/tests/camera.test.ts
+++ b/tests/camera.test.ts
@@ -1,0 +1,16 @@
+import { Camera } from '../src/core/camera';
+
+describe('Camera.screenToWorld', () => {
+  it('converts coordinates for various scales', () => {
+    const cam = new Camera();
+
+    expect(cam.screenToWorld(10, 20)).toEqual({ x: 10, y: 20 });
+
+    cam.scale = 2;
+    expect(cam.screenToWorld(10, 20)).toEqual({ x: 5, y: 10 });
+
+    cam.scale = 0.5;
+    expect(cam.screenToWorld(10, 20)).toEqual({ x: 20, y: 40 });
+  });
+});
+

--- a/tests/game.test.ts
+++ b/tests/game.test.ts
@@ -1,0 +1,44 @@
+import { Game } from '../src/core/game';
+import { Tile } from '../src/world';
+
+describe('Game interactions', () => {
+  function createGame(width = 2, height = 2) {
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    return new Game(ctx, width, height);
+  }
+
+  test('handleClick toggles tiles', () => {
+    const game = createGame(1, 1);
+    expect(game.world.get(0, 0)).toBe(Tile.Grass);
+    game.handleClick(0, 0);
+    expect(game.world.get(0, 0)).toBe(Tile.Water);
+    game.handleClick(0, 0);
+    expect(game.world.get(0, 0)).toBe(Tile.Grass);
+  });
+
+  test('handleClick ignores clicks outside the map', () => {
+    const game = createGame(1, 1);
+    game.handleClick(100, 100);
+    expect(game.world.get(0, 0)).toBe(Tile.Grass);
+  });
+
+  test('panning updates camera position', () => {
+    const game = createGame();
+    game.handleMouseDown(0, 0);
+    game.handleMouseMove(10, 5);
+    game.handleMouseUp();
+    expect(game.camera.x).toBe(10);
+    expect(game.camera.y).toBe(5);
+  });
+
+  test('wheel updates camera scale', () => {
+    const game = createGame();
+    const initial = game.camera.scale;
+    game.handleWheel(-1);
+    expect(game.camera.scale).toBeCloseTo(initial * 1.1);
+    game.handleWheel(1);
+    expect(game.camera.scale).toBeCloseTo(initial * 1.1 * 0.9);
+  });
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "baseUrl": "./src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- render visible map tiles with camera-aware World module
- pan, zoom, and click tiles in Game loop using Camera
- adjust tests to use new World and Tile exports

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*
- `npx jest --env=node --runInBand` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68abf7eb75308332ad60cbff08cecc04