### PR TITLE
feat: add tile rendering and camera controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "jest": {
     "preset": "ts-jest",
-    "testEnvironment": "jsdom",
+    "testEnvironment": "node",
     "setupFiles": ["jest-canvas-mock"]
   }
 }

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -1,5 +1,5 @@
 import { Camera } from './camera';
-import { Tile } from './tile';
+import { Tile, tileColor } from './tile';
 
 /**
  * Minimal game logic used for unit testing. It keeps a small tile map and a
@@ -9,13 +9,14 @@ export class Game {
   public readonly camera = new Camera();
   public readonly map: Tile[][];
 
-  private readonly tileSize = 1; // size of a tile in world units
+  /** size of a tile in pixels */
+  public readonly tileSize: number;
   private isPanning = false;
   private lastPan = { x: 0, y: 0 };
 
-  constructor(ctx: CanvasRenderingContext2D, width = 10, height = 10) {
-    // The rendering context is kept for completeness but is not used in tests.
+  constructor(ctx: CanvasRenderingContext2D, width = 10, height = 10, tileSize = 32) {
     this.ctx = ctx;
+    this.tileSize = tileSize;
     this.map = Array.from({ length: height }, () =>
       Array(width).fill(Tile.Grass)
     );
@@ -60,6 +61,33 @@ export class Game {
   handleWheel(deltaY: number) {
     const zoomFactor = deltaY > 0 ? 0.9 : 1.1;
     this.camera.scale *= zoomFactor;
+  }
+
+  /** Render the current map and grid. */
+  render() {
+    const { ctx } = this;
+    const width = ctx.canvas.width;
+    const height = ctx.canvas.height;
+
+    ctx.save();
+    ctx.clearRect(0, 0, width, height);
+    ctx.translate(this.camera.x, this.camera.y);
+    ctx.scale(this.camera.scale, this.camera.scale);
+
+    for (let y = 0; y < this.map.length; y++) {
+      for (let x = 0; x < this.map[y].length; x++) {
+        const tile = this.map[y][x];
+        const px = x * this.tileSize;
+        const py = y * this.tileSize;
+        ctx.fillStyle = tileColor(tile);
+        ctx.fillRect(px, py, this.tileSize, this.tileSize);
+        // grid overlay
+        ctx.strokeStyle = 'rgba(0,0,0,0.2)';
+        ctx.strokeRect(px, py, this.tileSize, this.tileSize);
+      }
+    }
+
+    ctx.restore();
   }
 }
 

--- a/src/core/tile.ts
+++ b/src/core/tile.ts
@@ -3,3 +3,14 @@ export enum Tile {
   Water,
 }
 
+/** Return a CSS color for the given tile type. */
+export function tileColor(tile: Tile): string {
+  switch (tile) {
+    case Tile.Water:
+      return '#1E90FF'; // dodger blue
+    case Tile.Grass:
+    default:
+      return '#228B22'; // forest green
+  }
+}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,29 @@ function bootstrap() {
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas 2D context not supported');
 
-  new Game(ctx);
+  const game = new Game(ctx);
+
+  // input handlers
+  canvas.addEventListener('click', (e) =>
+    game.handleClick(e.offsetX, e.offsetY)
+  );
+  canvas.addEventListener('mousedown', (e) =>
+    game.handleMouseDown(e.clientX, e.clientY)
+  );
+  window.addEventListener('mousemove', (e) =>
+    game.handleMouseMove(e.clientX, e.clientY)
+  );
+  window.addEventListener('mouseup', () => game.handleMouseUp());
+  canvas.addEventListener('wheel', (e) => {
+    e.preventDefault();
+    game.handleWheel(e.deltaY);
+  });
+
+  function loop() {
+    game.render();
+    requestAnimationFrame(loop);
+  }
+  loop();
 }
 
 bootstrap();

--- a/tests/game.test.ts
+++ b/tests/game.test.ts
@@ -2,10 +2,24 @@ import { Game } from '../src/core/game';
 import { Tile } from '../src/core/tile';
 
 describe('Game interactions', () => {
+  function createMockCtx(width = 100, height = 100): any {
+    return {
+      canvas: { width, height },
+      save: jest.fn(),
+      restore: jest.fn(),
+      clearRect: jest.fn(),
+      translate: jest.fn(),
+      scale: jest.fn(),
+      fillRect: jest.fn(),
+      strokeRect: jest.fn(),
+      fillStyle: '',
+      strokeStyle: '',
+    };
+  }
+
   function createGame(width = 2, height = 2) {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d')!;
-    return new Game(ctx, width, height);
+    const ctx = createMockCtx();
+    return new Game(ctx, width, height, 32);
   }
 
   test('handleClick toggles tiles', () => {
@@ -39,6 +53,19 @@ describe('Game interactions', () => {
     expect(game.camera.scale).toBeCloseTo(initial * 1.1);
     game.handleWheel(1); // zoom out
     expect(game.camera.scale).toBeCloseTo(initial * 1.1 * 0.9);
+  });
+
+  test('render draws tiles and grid with camera transform', () => {
+    const mockCtx = createMockCtx(64, 64);
+    const game = new Game(mockCtx, 2, 2, 32);
+    game.render();
+
+    expect(mockCtx.save).toHaveBeenCalled();
+    expect(mockCtx.clearRect).toHaveBeenCalledWith(0, 0, 64, 64);
+    expect(mockCtx.translate).toHaveBeenCalledWith(game.camera.x, game.camera.y);
+    expect(mockCtx.scale).toHaveBeenCalledWith(game.camera.scale, game.camera.scale);
+    expect(mockCtx.fillRect).toHaveBeenCalledTimes(4); // 2x2 tiles
+    expect(mockCtx.strokeRect).toHaveBeenCalledTimes(4); // grid overlay
   });
 });
 


### PR DESCRIPTION
## Summary
- render grid-based tile map with overlay and camera transforms
- attach mouse and wheel inputs for panning, zooming, and tile placement
- test rendering pipeline with mocked canvas context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac17c6e3e88332aa34c900d8e36e5c