### PR TITLE
Add isometric city builder prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Isometric City Builder
+
+A small prototype of an isometric city builder game with a simple economic simulation. Build farms, houses, lumber mills and markets to produce and consume resources.
+
+## Controls
+
+- `1` Farm
+- `2` House
+- `3` LumberMill
+- `4` Market
+- Left click to place the selected building on the grid.
+
+## Running
+
+```bash
+pip install pygame
+python main.py
+```

--- a/building.py
+++ b/building.py
@@ -1,0 +1,36 @@
+class Building:
+    name = 'Building'
+    production = {}
+    consumption = {}
+
+    def update(self, economy):
+        # Check if resources are available for consumption
+        for res, amount in self.consumption.items():
+            if economy.resources.get(res, 0) < amount:
+                return  # Not enough resources, skip production
+        for res, amount in self.consumption.items():
+            economy.resources[res] -= amount
+        for res, amount in self.production.items():
+            economy.resources[res] = economy.resources.get(res, 0) + amount
+
+
+class Farm(Building):
+    name = 'Farm'
+    production = {'food': 2}
+
+
+class House(Building):
+    name = 'House'
+    consumption = {'food': 1}
+    production = {'gold': 1}
+
+
+class LumberMill(Building):
+    name = 'LumberMill'
+    production = {'wood': 2}
+
+
+class Market(Building):
+    name = 'Market'
+    consumption = {'food': 1, 'wood': 1}
+    production = {'gold': 3}

--- a/economy.py
+++ b/economy.py
@@ -1,0 +1,15 @@
+class Economy:
+    def __init__(self):
+        self.resources = {
+            'food': 0,
+            'wood': 0,
+            'gold': 0,
+        }
+        self.buildings = []
+
+    def add_building(self, building):
+        self.buildings.append(building)
+
+    def update(self):
+        for building in self.buildings:
+            building.update(self)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,87 @@
+import os
+import pygame
+from tilemap import TileMap, TILE_WIDTH, TILE_HEIGHT, iso_to_screen, screen_to_iso
+from economy import Economy
+from building import Farm, House, LumberMill, Market
+
+# Allow running in headless mode for tests
+if os.environ.get('SDL_VIDEODRIVER') == 'dummy':
+    os.environ['SDL_AUDIODRIVER'] = 'dummy'
+
+WIDTH, HEIGHT = 800, 600
+MAP_WIDTH, MAP_HEIGHT = 10, 10
+
+BUILDING_TYPES = {
+    pygame.K_1: Farm,
+    pygame.K_2: House,
+    pygame.K_3: LumberMill,
+    pygame.K_4: Market,
+}
+
+COLORS = {
+    'Farm': (50, 205, 50),
+    'House': (176, 196, 222),
+    'LumberMill': (139, 69, 19),
+    'Market': (218, 165, 32),
+}
+
+def main():
+    pygame.init()
+    screen = pygame.display.set_mode((WIDTH, HEIGHT))
+    clock = pygame.time.Clock()
+    font = pygame.font.SysFont(None, 24)
+
+    tilemap = TileMap(MAP_WIDTH, MAP_HEIGHT)
+    economy = Economy()
+
+    selected_building = Farm
+    update_event = pygame.USEREVENT + 1
+    pygame.time.set_timer(update_event, 1000)  # economy update every second
+
+    running = True
+    while running:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                running = False
+            elif event.type == pygame.KEYDOWN:
+                if event.key in BUILDING_TYPES:
+                    selected_building = BUILDING_TYPES[event.key]
+            elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+                mx, my = event.pos
+                tx, ty = screen_to_iso(mx - WIDTH // 2, my)
+                tile = tilemap.get_tile(tx, ty)
+                if tile and tile.building is None:
+                    b = selected_building()
+                    tile.building = b
+                    economy.add_building(b)
+            elif event.type == update_event:
+                economy.update()
+
+        screen.fill((135, 206, 235))
+        for x in range(MAP_WIDTH):
+            for y in range(MAP_HEIGHT):
+                screen_x, screen_y = iso_to_screen(x, y)
+                screen_x += WIDTH // 2
+                points = [
+                    (screen_x, screen_y),
+                    (screen_x + TILE_WIDTH // 2, screen_y + TILE_HEIGHT // 2),
+                    (screen_x, screen_y + TILE_HEIGHT),
+                    (screen_x - TILE_WIDTH // 2, screen_y + TILE_HEIGHT // 2),
+                ]
+                pygame.draw.polygon(screen, (34, 139, 34), points, 1)
+                tile = tilemap.tiles[x][y]
+                if tile.building:
+                    color = COLORS.get(tile.building.name, (255, 255, 255))
+                    pygame.draw.polygon(screen, color, points)
+
+        res_text = ", ".join(f"{k}: {v}" for k, v in economy.resources.items())
+        text_surf = font.render(res_text, True, (0, 0, 0))
+        screen.blit(text_surf, (5, 5))
+
+        pygame.display.flip()
+        clock.tick(60)
+
+    pygame.quit()
+
+if __name__ == '__main__':
+    main()

--- a/tilemap.py
+++ b/tilemap.py
@@ -1,0 +1,32 @@
+TILE_WIDTH = 64
+TILE_HEIGHT = 32
+
+class Tile:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+        self.building = None
+
+
+class TileMap:
+    def __init__(self, width, height):
+        self.width = width
+        self.height = height
+        self.tiles = [[Tile(x, y) for y in range(height)] for x in range(width)]
+
+    def get_tile(self, x, y):
+        if 0 <= x < self.width and 0 <= y < self.height:
+            return self.tiles[x][y]
+        return None
+
+
+def iso_to_screen(x, y):
+    screen_x = (x - y) * TILE_WIDTH // 2
+    screen_y = (x + y) * TILE_HEIGHT // 2
+    return screen_x, screen_y
+
+
+def screen_to_iso(screen_x, screen_y):
+    x = (screen_x / (TILE_WIDTH / 2) + screen_y / (TILE_HEIGHT / 2)) / 2
+    y = (screen_y / (TILE_HEIGHT / 2) - (screen_x / (TILE_WIDTH / 2))) / 2
+    return int(x), int(y)


### PR DESCRIPTION
## Summary
- implement basic isometric renderer using pygame
- add building and economy simulation with multiple resource types
- provide controls and usage instructions in README

## Testing
- `python -m py_compile economy.py building.py tilemap.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0fd0065c48332a0b0f849437ba9cd