### PR TITLE
feat: add browser-based isometric city builder

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Isometric City Builder</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <canvas id="gameCanvas" width="800" height="600"></canvas>
+    <div id="ui"></div>
+    <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "city-builder",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/src/buildings.js
+++ b/src/buildings.js
@@ -1,0 +1,64 @@
+import { drawTile } from './isometric.js';
+
+export class Building {
+    constructor(x, y) {
+        this.x = x;
+        this.y = y;
+        this.color = '#ccc';
+    }
+
+    update(economy) {}
+
+    draw(ctx) {
+        drawTile(ctx, this.x, this.y, this.color);
+    }
+}
+
+export class Farm extends Building {
+    constructor(x, y) {
+        super(x, y);
+        this.color = '#3a3';
+    }
+    update(economy) {
+        economy.market.supply('food', 1);
+    }
+}
+
+export class House extends Building {
+    constructor(x, y) {
+        super(x, y);
+        this.color = '#a33';
+    }
+    update(economy) {
+        const food = economy.market.request('food', 1);
+        if (food === 1) {
+            economy.population += 0.01;
+            economy.funds += 1;
+        } else {
+            economy.population = Math.max(0, economy.population - 0.01);
+        }
+    }
+}
+
+export class LumberMill extends Building {
+    constructor(x, y) {
+        super(x, y);
+        this.color = '#964B00';
+    }
+    update(economy) {
+        economy.market.supply('wood', 1);
+    }
+}
+
+export class Factory extends Building {
+    constructor(x, y) {
+        super(x, y);
+        this.color = '#555';
+    }
+    update(economy) {
+        const wood = economy.market.request('wood', 1);
+        if (wood === 1) {
+            economy.market.supply('goods', 1);
+        }
+    }
+}

--- a/src/economy.js
+++ b/src/economy.js
@@ -1,0 +1,42 @@
+export class Market {
+    constructor() {
+        this.goods = {};
+    }
+
+    registerGood(name, basePrice = 1) {
+        this.goods[name] = { stock: 0, price: basePrice, demand: 0 };
+    }
+
+    request(name, qty) {
+        const g = this.goods[name];
+        if (!g) return 0;
+        const bought = Math.min(qty, g.stock);
+        g.stock -= bought;
+        g.demand += qty - bought;
+        return bought;
+    }
+
+    supply(name, qty) {
+        const g = this.goods[name];
+        if (!g) return;
+        g.stock += qty;
+    }
+
+    update() {
+        for (const g of Object.values(this.goods)) {
+            const imbalance = g.demand - g.stock;
+            g.price *= 1 + 0.05 * imbalance / Math.max(1, g.stock);
+            if (g.price < 0.1) g.price = 0.1;
+            g.demand = 0;
+        }
+    }
+}
+
+export class Economy {
+    constructor() {
+        this.market = new Market();
+        ['food', 'wood', 'goods'].forEach(g => this.market.registerGood(g, 1));
+        this.funds = 100;
+        this.population = 0;
+    }
+}

--- a/src/game.js
+++ b/src/game.js
@@ -1,0 +1,48 @@
+import { drawTile, isoToScreen, TILE_WIDTH, TILE_HEIGHT } from './isometric.js';
+import { Farm, House, LumberMill, Factory } from './buildings.js';
+import { Economy } from './economy.js';
+
+export class Game {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.ctx = canvas.getContext('2d');
+        this.offsetX = canvas.width / 2;
+        this.offsetY = 50;
+        this.mapSize = 10;
+        this.buildings = [];
+        this.economy = new Economy();
+        this.selected = Farm;
+        canvas.addEventListener('click', e => this.handleClick(e));
+    }
+
+    handleClick(e) {
+        const rect = this.canvas.getBoundingClientRect();
+        const mx = e.clientX - rect.left - this.offsetX;
+        const my = e.clientY - rect.top - this.offsetY;
+        const y = Math.floor((mx / (TILE_WIDTH / 2) + my / (TILE_HEIGHT / 2)) / 2);
+        const x = Math.floor((my / (TILE_HEIGHT / 2) - mx / (TILE_WIDTH / 2)) / 2);
+        if (x >= 0 && y >= 0 && x < this.mapSize && y < this.mapSize) {
+            this.buildings.push(new this.selected(x, y));
+        }
+    }
+
+    update() {
+        this.buildings.forEach(b => b.update(this.economy));
+        this.economy.market.update();
+    }
+
+    draw() {
+        this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.ctx.save();
+        this.ctx.translate(this.offsetX, this.offsetY);
+        for (let y = 0; y < this.mapSize; y++) {
+            for (let x = 0; x < this.mapSize; x++) {
+                drawTile(this.ctx, x, y, '#3d9943');
+            }
+        }
+        this.buildings.forEach(b => b.draw(this.ctx));
+        this.ctx.restore();
+    }
+}
+
+export const buildingTypes = { Farm, House, LumberMill, Factory };

--- a/src/isometric.js
+++ b/src/isometric.js
@@ -1,0 +1,21 @@
+export const TILE_WIDTH = 64;
+export const TILE_HEIGHT = 32;
+
+export function isoToScreen(x, y) {
+    return {
+        x: (x - y) * TILE_WIDTH / 2,
+        y: (x + y) * TILE_HEIGHT / 2
+    };
+}
+
+export function drawTile(ctx, x, y, color) {
+    const p = isoToScreen(x, y);
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.lineTo(p.x + TILE_WIDTH / 2, p.y + TILE_HEIGHT / 2);
+    ctx.lineTo(p.x, p.y + TILE_HEIGHT);
+    ctx.lineTo(p.x - TILE_WIDTH / 2, p.y + TILE_HEIGHT / 2);
+    ctx.closePath();
+    ctx.fill();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,27 @@
+import { Game, buildingTypes } from './game.js';
+
+const canvas = document.getElementById('gameCanvas');
+const game = new Game(canvas);
+
+const ui = document.getElementById('ui');
+for (const [name, cls] of Object.entries(buildingTypes)) {
+    const btn = document.createElement('button');
+    btn.textContent = name;
+    btn.onclick = () => game.selected = cls;
+    ui.appendChild(btn);
+}
+const info = document.createElement('div');
+ui.appendChild(info);
+
+function loop() {
+    game.update();
+    game.draw();
+    const goods = game.economy.market.goods;
+    info.innerHTML = `Funds: ${game.economy.funds.toFixed(1)}<br>
+    Pop: ${game.economy.population.toFixed(1)}<br>
+    Food: ${goods.food.stock.toFixed(1)} (p: ${goods.food.price.toFixed(2)})<br>
+    Wood: ${goods.wood.stock.toFixed(1)} (p: ${goods.wood.price.toFixed(2)})<br>
+    Goods: ${goods.goods.stock.toFixed(1)} (p: ${goods.goods.price.toFixed(2)})`;
+    requestAnimationFrame(loop);
+}
+loop();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+body {
+    margin: 0;
+    overflow: hidden;
+    background: #222;
+    color: #fff;
+    font-family: sans-serif;
+}
+#ui {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(0,0,0,0.5);
+    padding: 10px;
+    border-radius: 4px;
+}
+canvas {
+    display: block;
+    background: #4f8;
+}


### PR DESCRIPTION
## Summary
- set up canvas-based isometric tile renderer
- implement basic city economy with dynamic market prices
- add placeable building types: Farm, House, Lumber Mill, Factory

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0fecb894c8332bd207f7f56bde9bc